### PR TITLE
Prerequisite to allow lstore-release to build for distros with deb packaging

### DIFF
--- a/CPackConfig.cmake
+++ b/CPackConfig.cmake
@@ -11,9 +11,12 @@ set(CPACK_INSTALL_COMMANDS "${CMAKE_CURRENT_LIST_DIR}/configure --prefix=/usr --
 
 ### general settings
 set(CPACK_PACKAGE_NAME ${APPLICATION_NAME})
+set(CPACK_DEBIAN_PACKAGE_NAME "libapr-accre-util1")     
+# ^^^ use this package name for debs b/c it is what makes dpkg-shlibdeps happy
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "ACCRE-modified libapr-util")
 set(CPACK_PACKAGE_DESCRIPTION "APR-Util+some additional ACCRE patches")
 #set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/README")
+set(CPACK_PACKAGE_CONTACT "Andrew Melo or Alan Tackett")
 set(CPACK_PACKAGE_VENDOR "ACCRE")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY ${CPACK_PACKAGE_NAME})
 #set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/COPYING")
@@ -38,9 +41,9 @@ if (WIN32)
     find_package(NSIS)
     if (NSIS_MAKE)
         set(CPACK_GENERATOR "${CPACK_GENERATOR};NSIS")
-        set(CPACK_NSIS_DISPLAY_NAME "The SSH Library")
+        set(CPACK_NSIS_DISPLAY_NAME ${APPLICATION_NAME})
         set(CPACK_NSIS_COMPRESSOR "/SOLID zlib")
-        set(CPACK_NSIS_MENU_LINKS "http://www.libssh.org/" "libssh homepage")
+        set(CPACK_NSIS_MENU_LINKS "http://apr.apache.org/" "libapr homepage")
     endif (NSIS_MAKE)
 endif (WIN32)
 
@@ -51,9 +54,9 @@ set(CPACK_PACKAGE_FILE_NAME ${APPLICATION_NAME}-${CPACK_PACKAGE_VERSION})
 set(CPACK_COMPONENT_LIBRARIES_DISPLAY_NAME "Libraries")
 set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "C/C++ Headers")
 set(CPACK_COMPONENT_LIBRARIES_DESCRIPTION
-  "Libraries used to build programs which use libssh")
+  "Libraries used to build programs which use libapr")
 set(CPACK_COMPONENT_HEADERS_DESCRIPTION
-  "C/C++ header files for use with libssh")
+  "C/C++ header files for use with libapr")
 set(CPACK_COMPONENT_HEADERS_DEPENDS libraries)
 #set(CPACK_COMPONENT_APPLICATIONS_GROUP "Runtime")
 set(CPACK_COMPONENT_LIBRARIES_GROUP "Development")


### PR DESCRIPTION
Add debian package name and package contact/maintainer plus CPack cleanup
